### PR TITLE
fix: Tabs overflow handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@fontsource/geist-mono": "^5.0.3",
 		"@fontsource/geist-sans": "^5.0.3",
 		"@poppanator/sveltekit-svg": "4.2.1",
+		"@pyncz/tailwind-mask-image": "^2.0.0",
 		"@sveltejs/adapter-static": "^3.0.2",
 		"@sveltejs/kit": "^2.5.18",
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@poppanator/sveltekit-svg':
         specifier: 4.2.1
         version: 4.2.1(rollup@4.19.0)(svelte@4.2.18)(svgo@3.3.2)(vite@5.3.4)
+      '@pyncz/tailwind-mask-image':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sveltejs/adapter-static':
         specifier: ^3.0.2
         version: 3.0.2(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.3.4))(svelte@4.2.18)(vite@5.3.4))
@@ -318,6 +321,9 @@ packages:
       svelte: '>=4.x'
       svgo: '>=3.x'
       vite: '>=4.x'
+
+  '@pyncz/tailwind-mask-image@2.0.0':
+    resolution: {integrity: sha512-BN52RPSp56VIA25ZpLD3SEigwADTrQ6a3Kq8x94rbhU6YP1HpvRjSYtnFenEfGw2nzESvFsNdYT6KKP+JuS73w==}
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -1746,6 +1752,8 @@ snapshots:
       vite: 5.3.4
     transitivePeerDependencies:
       - rollup
+
+  '@pyncz/tailwind-mask-image@2.0.0': {}
 
   '@rollup/pluginutils@5.1.0(rollup@4.19.0)':
     dependencies:

--- a/src/lib/components/shared/demo.svelte
+++ b/src/lib/components/shared/demo.svelte
@@ -70,7 +70,7 @@
 		</p>
 	{/if}
 	<div
-		class="group relative mt-4 w-full overflow-x-auto rounded-xl border border-gray-alpha-400 bg-background-100 md:overflow-visible xl:mt-7"
+		class="group relative mt-4 overflow-x-auto rounded-xl border border-gray-alpha-400 bg-background-100 xl:mt-7"
 	>
 		<section id="component-demo" class={cn('w-full p-6', class_name)}>
 			<slot></slot>

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils.js';
 	import { Tabs as TabsPrimitive } from 'bits-ui';
+	import { onMount } from 'svelte';
 
 	type $$Props = TabsPrimitive.ListProps & {
 		variant?: 'default' | 'secondary';
@@ -9,16 +10,54 @@
 	let class_name: $$Props['class'] = undefined;
 	export let variant: $$Props['variant'] = 'default';
 	export { class_name as class };
+
+	let el: HTMLDivElement;
+
+	let preBlur = false;
+	let postBlur = false;
+
+	// When the tabs are scrolled it will determine whether or not to show the blur at the end
+	const scroll = () => {
+		if (el.offsetWidth + el.scrollLeft < el.scrollWidth) {
+			postBlur = true;
+		} else {
+			postBlur = false;
+		}
+
+		if (el.scrollLeft == 0) {
+			preBlur = false;
+		} else {
+			preBlur = true;
+		}
+	};
+
+	onMount(() => {
+		scroll(); // initially determine blur state
+		el.addEventListener('scroll', scroll); // on:scroll listener doesn't work on TabsPrimitive
+
+		return () => {
+			el.removeEventListener('scroll', scroll);
+		};
+	});
 </script>
 
-<!-- TODO: Add a no-scrollbar class. -->
+<!-- Make sure you have the `no-scrollbar` class in your tailwind.config file -->
+
 <TabsPrimitive.List
 	data-variant={variant}
+	bind:el
 	class={cn(
-		'group inline-flex w-full flex-wrap items-baseline gap-3 overflow-hidden overflow-x-auto p-1 text-gray-900 data-[variant=default]:[box-shadow:_0_-1px_0_var(--accents-2)_inset;]',
+		'group flex w-full items-baseline gap-3 overflow-hidden overflow-x-auto p-1 text-gray-900 no-scrollbar data-[variant=default]:[box-shadow:_0_-1px_0_var(--accents-2)_inset;]',
 		class_name
 	)}
 	{...$$restProps}
 >
+	{#if preBlur}
+		<span class="absolute left-4 h-10 w-8 bg-gray-100 bg-opacity-80 blur-lg"></span>
+	{/if}
 	<slot />
+	<!-- This indicates to the user that there is more content -->
+	{#if postBlur}
+		<span class="absolute right-4 h-10 w-8 bg-gray-100 bg-opacity-80 blur-lg"></span>
+	{/if}
 </TabsPrimitive.List>

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -13,7 +13,7 @@
 	let class_name: $$Props['class'] = undefined;
 	export let variant: $$Props['variant'] = 'default';
 	export { class_name as class };
-	export let blur_overflow: $$Props['blur_overflow'] = false;
+	export let blur_overflow: $$Props['blur_overflow'] = true;
 
 	let el: HTMLDivElement;
 

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -36,7 +36,7 @@
 	});
 </script>
 
-<svelte:window on:scroll={handle_blur} on:resize={handle_blur}/>
+<svelte:window on:scroll={handle_blur} on:resize={handle_blur} />
 
 <!-- Make sure you have the `no-scrollbar` class in your tailwind.config file -->
 

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -17,7 +17,7 @@
 	let postBlur = false;
 
 	// When the tabs are scrolled it will determine whether or not to show the blur at the end
-	const scroll = () => {
+	const handle_blur = () => {
 		if (el.offsetWidth + el.scrollLeft < el.scrollWidth) {
 			postBlur = true;
 		} else {
@@ -32,14 +32,11 @@
 	};
 
 	onMount(() => {
-		scroll(); // initially determine blur state
-		el.addEventListener('scroll', scroll); // on:scroll listener doesn't work on TabsPrimitive
-
-		return () => {
-			el.removeEventListener('scroll', scroll);
-		};
+		handle_blur(); // initially determine blur state
 	});
 </script>
+
+<svelte:window on:scroll={handle_blur} on:resize={handle_blur}/>
 
 <!-- Make sure you have the `no-scrollbar` class in your tailwind.config file -->
 

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -2,14 +2,18 @@
 	import { cn } from '$lib/utils.js';
 	import { Tabs as TabsPrimitive } from 'bits-ui';
 	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
 
 	type $$Props = TabsPrimitive.ListProps & {
 		variant?: 'default' | 'secondary';
+		/** When true blurs either edge of the scrollable content to indicate there is more content to the user @default true */
+		blur_overflow?: boolean;
 	};
 
 	let class_name: $$Props['class'] = undefined;
 	export let variant: $$Props['variant'] = 'default';
 	export { class_name as class };
+	export let blur_overflow: $$Props['blur_overflow'] = false;
 
 	let el: HTMLDivElement;
 
@@ -18,7 +22,7 @@
 
 	// When the tabs are scrolled it will determine whether or not to show the blur at the end
 	const handle_blur = () => {
-		if (el.offsetWidth + el.scrollLeft < el.scrollWidth) {
+		if (el.offsetWidth + el.scrollLeft < el.scrollWidth - 10) {
 			postBlur = true;
 		} else {
 			postBlur = false;
@@ -33,28 +37,43 @@
 
 	onMount(() => {
 		handle_blur(); // initially determine blur state
+		el.addEventListener('scroll', handle_blur);
+
+		return () => {
+			el.removeEventListener('scroll', handle_blur);
+		};
 	});
 </script>
 
-<svelte:window on:scroll={handle_blur} on:resize={handle_blur} />
+<svelte:window on:resize={handle_blur} on:scroll={handle_blur} />
 
 <!-- Make sure you have the `no-scrollbar` class in your tailwind.config file -->
 
-<TabsPrimitive.List
-	data-variant={variant}
-	bind:el
-	class={cn(
-		'group flex w-full items-baseline gap-3 overflow-hidden overflow-x-auto p-1 text-gray-900 no-scrollbar data-[variant=default]:[box-shadow:_0_-1px_0_var(--accents-2)_inset;]',
-		class_name
-	)}
-	{...$$restProps}
->
-	{#if preBlur}
-		<span class="absolute left-4 h-10 w-8 bg-gray-100 bg-opacity-80 blur-lg"></span>
-	{/if}
-	<slot />
-	<!-- This indicates to the user that there is more content -->
-	{#if postBlur}
-		<span class="absolute right-4 h-10 w-8 bg-gray-100 bg-opacity-80 blur-lg"></span>
-	{/if}
-</TabsPrimitive.List>
+<div class="relative">
+	<TabsPrimitive.List
+		data-variant={variant}
+		bind:el
+		class={cn(
+			'group flex w-full items-baseline gap-3 overflow-hidden overflow-x-auto p-1 text-gray-900 no-scrollbar data-[variant=default]:[box-shadow:_0_-1px_0_var(--accents-2)_inset;]',
+			class_name
+		)}
+		{...$$restProps}
+	>
+		{#if preBlur && blur_overflow}
+			<span
+				in:fade={{ duration: 50 }}
+				out:fade={{ duration: 50 }}
+				class="pointer-events-none absolute left-0 top-0 z-[1] h-full w-8 bg-gray-100 bg-opacity-80 blur-lg dark:bg-gray-200"
+			></span>
+		{/if}
+		<slot />
+		<!-- This indicates to the user that there is more content -->
+		{#if postBlur && blur_overflow}
+			<span
+				in:fade={{ duration: 50 }}
+				out:fade={{ duration: 50 }}
+				class="pointer-events-none absolute right-0 top-0 z-[1] h-full w-8 bg-gray-100 bg-opacity-80 blur-lg dark:bg-gray-200"
+			></span>
+		{/if}
+	</TabsPrimitive.List>
+</div>

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -45,7 +45,7 @@
 	});
 </script>
 
-<svelte:window on:resize={handle_blur} on:scroll={handle_blur} />
+<svelte:window on:resize={handle_blur} />
 
 <!-- Make sure you have the `no-scrollbar` class in your tailwind.config file -->
 

--- a/src/routes/tabs/+page.svelte
+++ b/src/routes/tabs/+page.svelte
@@ -5,6 +5,8 @@
 	import default_code from './default.svelte?raw';
 	import DisableSpecificTabs from './disable-specific-tabs.svelte';
 	import disable_specific_tabs_code from './disable-specific-tabs.svelte?raw';
+	import Overflow from './overflow-tabs.svelte';
+	import overflow_code from './overflow-tabs.svelte?raw';
 	import Secondary from './secondary.svelte';
 	import secondary_code from './secondary.svelte?raw';
 	import WithIcons from './with-icons.svelte';
@@ -28,5 +30,9 @@
 
 	<Demo id="secondary" code={secondary_code}>
 		<Secondary />
+	</Demo>
+
+	<Demo id="overflow" code={overflow_code}>
+		<Overflow />
 	</Demo>
 </PageWrapper>

--- a/src/routes/tabs/overflow-tabs.svelte
+++ b/src/routes/tabs/overflow-tabs.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import * as Tabs from '$lib/components/ui/tabs';
+
+	const tabs = [
+		{ title: 'Apple', value: 'apple' },
+		{ title: 'Banana', value: 'banana' },
+		{ title: 'Orange', value: 'orange' },
+		{ title: 'Strawberry', value: 'strawberry' },
+		{ title: 'Mango', value: 'mango' },
+		{ title: 'Pineapple', value: 'pineapple' },
+		{ title: 'Grape', value: 'grape' },
+		{ title: 'Watermelon', value: 'watermelon' },
+		{ title: 'Peach', value: 'peach' },
+		{ title: 'Kiwi', value: 'kiwi' },
+		{ title: 'Cherry', value: 'cherry' },
+		{ title: 'Blueberry', value: 'blueberry' },
+		{ title: 'Pear', value: 'pear' },
+		{ title: 'Plum', value: 'plum' },
+		{ title: 'Raspberry', value: 'raspberry' }
+	];
+</script>
+
+<Tabs.Root value="apple">
+	<Tabs.List>
+		{#each tabs as { title, value }}
+			<Tabs.Trigger {value}>{title}</Tabs.Trigger>
+		{/each}
+	</Tabs.List>
+</Tabs.Root>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -156,7 +156,21 @@ const config: Config = {
 			}
 		}
 	},
-	plugins: [typography]
+	plugins: [
+		typography,
+		function ({ addUtilities }) {
+			const newUtilities = {
+				'.no-scrollbar': {
+					'-ms-overflow-style': 'none',
+					'scrollbar-width': 'none',
+					'&::-webkit-scrollbar': {
+						display: 'none'
+					}
+				}
+			};
+			addUtilities(newUtilities);
+		}
+	]
 };
 
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,4 @@
+import mask from '@pyncz/tailwind-mask-image';
 import typography from '@tailwindcss/typography';
 import type { Config } from 'tailwindcss';
 import { fontFamily } from 'tailwindcss/defaultTheme';
@@ -158,6 +159,7 @@ const config: Config = {
 	},
 	plugins: [
 		typography,
+		mask,
 		function ({ addUtilities }) {
 			const newUtilities = {
 				'.no-scrollbar': {


### PR DESCRIPTION
Currently the tabs component uses flex-wrap so the tabs stack on overflow.

- Updated the tabs component to properly handle horizontal scrolling
- Added `no-scrollbar` class to hide the scrollbar
- Added `preBlur` and `postBlur` to show the user that there is more content to be scrolled.
- Added example with overflow (Vercel doesn't have this so I can axe it after review if necessary)