### PR TITLE
chore: bump jsrepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Configure paths in `jsrepo.json`:
 
 ```diff
 {
-	"$schema": "https://unpkg.com/jsrepo@1.33.0/schemas/project-config.json",
+	"$schema": "https://unpkg.com/jsrepo@1.34.0/schemas/project-config.json",
 	"repos": ["github/shyakadavis/geist"],
 	"includeTests": false,
 	"watermark": true,

--- a/jsrepo-build-config.json
+++ b/jsrepo-build-config.json
@@ -37,7 +37,7 @@
 	],
 	"doNotListCategories": ["icons", "lib"],
 	"preview": true,
-	"excludeDeps": ["svelte"],
+	"excludeDeps": ["svelte", "@sveltejs/kit", "vite", "tailwindcss"],
 	"rules": {
 		"no-category-index-file-dependency": "off",
 		"require-local-dependency-exists": "error",

--- a/jsrepo-manifest.json
+++ b/jsrepo-manifest.json
@@ -10,19 +10,29 @@
 			"name": "Global CSS",
 			"path": "./src/app.css",
 			"expectedPath": "./src/app.css",
-			"optional": false
+			"optional": false,
+			"dependencies": [],
+			"devDependencies": []
 		},
 		{
 			"name": "Tailwind Config",
 			"path": "./tailwind.config.ts",
 			"expectedPath": "./tailwind.config.ts",
-			"optional": false
+			"optional": false,
+			"dependencies": [],
+			"devDependencies": [
+				"@pyncz/tailwind-mask-image@^2.0.0",
+				"@tailwindcss/typography@^0.5.16",
+				"tailwindcss-animate@^1.0.7"
+			]
 		},
 		{
 			"name": "Vite config",
 			"path": "./vite.config.ts",
 			"expectedPath": "./vite.config.ts",
-			"optional": false
+			"optional": false,
+			"dependencies": [],
+			"devDependencies": ["@poppanator/sveltekit-svg@5.0.0"]
 		}
 	],
 	"categories": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"autoprefixer": "^10.4.20",
 		"bits-ui": "1.0.0-next.85",
 		"clsx": "^2.1.1",
-		"jsrepo": "^1.33.0",
+		"jsrepo": "^1.34.0",
 		"lucide-svelte": "^0.475.0",
 		"mode-watcher": "^0.5.1",
 		"postcss": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       jsrepo:
-        specifier: ^1.33.0
-        version: 1.33.0(typescript@5.7.3)
+        specifier: ^1.34.0
+        version: 1.34.0(typescript@5.7.3)
       lucide-svelte:
         specifier: ^0.475.0
         version: 0.475.0(svelte@5.19.9)
@@ -1257,8 +1257,8 @@ packages:
   json-schema-typed@8.0.1:
     resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
 
-  jsrepo@1.33.0:
-    resolution: {integrity: sha512-vqyrv5O6CE6B5xf2ldW2UXwJhFhSirlrCJLy6YRnreW3jWeFtMsQwHuUziitjn7mT6fpJn/iO2B7qwopIUoDqQ==}
+  jsrepo@1.34.0:
+    resolution: {integrity: sha512-BGIrOQKkl+cr7EDCEFqsHg1i83EO1Q8zfS+oa7eJkgDJw1SmVGdOx4hI0SDUac3RWPDneWi4FrjIcmWcK4YO7A==}
     hasBin: true
 
   kleur@4.1.5:
@@ -3278,7 +3278,7 @@ snapshots:
 
   json-schema-typed@8.0.1: {}
 
-  jsrepo@1.33.0(typescript@5.7.3):
+  jsrepo@1.34.0(typescript@5.7.3):
     dependencies:
       '@anthropic-ai/sdk': 0.36.3
       '@biomejs/js-api': 0.7.1(@biomejs/wasm-nodejs@1.9.4)


### PR DESCRIPTION
Just merged https://github.com/ieedan/jsrepo/pull/425 which allows config files to have remote dependencies. 

With this users that are using the CLI shouldn't need to do any manual configuration anymore as they won't need to install any dependencies if they run `init` through the jsrepo CLI.

P.S. I decided not to pin `tailwindcss` but I am not sure if that's the right choice or not...